### PR TITLE
Patch for maybe not wanted email address disclosure

### DIFF
--- a/easy-author-image/easy-author-image.php
+++ b/easy-author-image/easy-author-image.php
@@ -202,7 +202,7 @@ function get_easy_author_image($avatar, $email, $size, $default='', $alt='') {
 			
 			// No author_profile_picture set OR user does not belong to blog, so default to Gravatar
 			$gravatarUrl = "http://www.gravatar.com/avatar.php?gravatar_id=" . md5($email->comment_author_email) . "&size=40";
-			$myavatar = "<img src='$gravatarUrl' height='64' width='64' alt='{$safe_alt}' />";
+			$myavatar = "<img src='$gravatarUrl' height='64' width='64' alt='$safe_alt' />";
 		}
 	}
 			


### PR DESCRIPTION
Hi Jesse

I have tried to fix it.
The alt attribute of the image tag is now controlled directly by Wordpress, so it should work now as expected. 
If $alt is set we escape the $alt function parameter and add it to the image.

Cheers
George

( https://github.com/George-Ruethschilling/easy-author-image/tree/master/easy-author-image )
